### PR TITLE
Sync application resource, when an application resource on argocd namespace is deleted.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,24 @@ dev:
 stop-dev:
 	ctlptl delete -f ./cluster.yaml
 
+.PHONY: port-forward-argocd
+port-forward-argocd:
+	mkdir -p ./tmp/
+	kubectl port-forward -n argocd service/argocd-server 8080:80 > /dev/null 2>&1 & jobs -p > ./tmp/port-forward-argocd.pid
+
+.PHONY: stop-port-forward-argocd
+stop-port-forward-argocd:
+	echo "kill `cat ./tmp/port-forward-argocd.pid`" && kill `cat ./tmp/port-forward-argocd.pid`
+	rm ./tmp/port-forward-argocd.pid
+
+.PHONY: argocd-password
+argocd-password: ## Show admin password for ArgoCD
+	@kubectl get secret -n argocd argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d
+
+.PHONY: login-argocd
+login-argocd:
+	argocd login localhost:8080 --insecure --username admin --password $$(kubectl get secret -n argocd argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
+
 ##@ Tools
 
 CONTROLLER_GEN := $(BIN_DIR)/controller-gen


### PR DESCRIPTION
Reconcile process is not triggered when an application resource on argocd namespace is deleted.
Fix it to queue the tenant application when it detects the deletion of an application resource.

Signed-off-by: zoetrope <a.ikezoe@gmail.com>