### PR TITLE
Remove namespace label from custom metrics

### DIFF
--- a/controllers/tenant_controller.go
+++ b/controllers/tenant_controller.go
@@ -718,17 +718,17 @@ func (r *TenantReconciler) updateAllTenantNamespacesConfigMap(ctx context.Contex
 func (r *TenantReconciler) setMetrics(tenant *cattagev1beta1.Tenant) {
 	switch tenant.Status.Health {
 	case cattagev1beta1.TenantHealthy:
-		metrics.HealthyVec.WithLabelValues(tenant.Name, tenant.Namespace).Set(1)
-		metrics.UnhealthyVec.WithLabelValues(tenant.Name, tenant.Namespace).Set(0)
+		metrics.HealthyVec.WithLabelValues(tenant.Name).Set(1)
+		metrics.UnhealthyVec.WithLabelValues(tenant.Name).Set(0)
 	case cattagev1beta1.TenantUnhealthy:
-		metrics.HealthyVec.WithLabelValues(tenant.Name, tenant.Namespace).Set(0)
-		metrics.UnhealthyVec.WithLabelValues(tenant.Name, tenant.Namespace).Set(1)
+		metrics.HealthyVec.WithLabelValues(tenant.Name).Set(0)
+		metrics.UnhealthyVec.WithLabelValues(tenant.Name).Set(1)
 	}
 }
 
 func (r *TenantReconciler) removeMetrics(tenant *cattagev1beta1.Tenant) {
-	metrics.HealthyVec.DeleteLabelValues(tenant.Name, tenant.Namespace)
-	metrics.UnhealthyVec.DeleteLabelValues(tenant.Name, tenant.Namespace)
+	metrics.HealthyVec.DeleteLabelValues(tenant.Name)
+	metrics.UnhealthyVec.DeleteLabelValues(tenant.Name)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/tenant_controller_test.go
+++ b/controllers/tenant_controller_test.go
@@ -623,18 +623,18 @@ var _ = Describe("Tenant controller", Ordered, func() {
 			expected := `
 			# HELP cattage_tenant_healthy The tenant status about healthy condition
 			# TYPE cattage_tenant_healthy gauge
-			cattage_tenant_healthy{name="a-team",namespace=""} 1
-			cattage_tenant_healthy{name="c-team",namespace=""} 1
-			cattage_tenant_healthy{name="m-team",namespace=""} 1
-			cattage_tenant_healthy{name="x-team",namespace=""} 1
-			cattage_tenant_healthy{name="y-team",namespace=""} 1
+			cattage_tenant_healthy{name="a-team"} 1
+			cattage_tenant_healthy{name="c-team"} 1
+			cattage_tenant_healthy{name="m-team"} 1
+			cattage_tenant_healthy{name="x-team"} 1
+			cattage_tenant_healthy{name="y-team"} 1
 			# HELP cattage_tenant_unhealthy The tenant status about unhealthy condition
 			# TYPE cattage_tenant_unhealthy gauge
-			cattage_tenant_unhealthy{name="a-team",namespace=""} 0
-			cattage_tenant_unhealthy{name="c-team",namespace=""} 0
-			cattage_tenant_unhealthy{name="m-team",namespace=""} 0
-			cattage_tenant_unhealthy{name="x-team",namespace=""} 0
-			cattage_tenant_unhealthy{name="y-team",namespace=""} 0
+			cattage_tenant_unhealthy{name="a-team"} 0
+			cattage_tenant_unhealthy{name="c-team"} 0
+			cattage_tenant_unhealthy{name="m-team"} 0
+			cattage_tenant_unhealthy{name="x-team"} 0
+			cattage_tenant_unhealthy{name="y-team"} 0
 			`
 			expectedReader := strings.NewReader(expected)
 			if err := testutil.GatherAndCompare(k8smetrics.Registry, expectedReader, customMetricsNames...); err != nil {
@@ -661,18 +661,18 @@ var _ = Describe("Tenant controller", Ordered, func() {
 			expected := `
 			# HELP cattage_tenant_healthy The tenant status about healthy condition
 			# TYPE cattage_tenant_healthy gauge
-			cattage_tenant_healthy{name="a-team",namespace=""} 1
-			cattage_tenant_healthy{name="c-team",namespace=""} 1
-			cattage_tenant_healthy{name="m-team",namespace=""} 0
-			cattage_tenant_healthy{name="x-team",namespace=""} 1
-			cattage_tenant_healthy{name="y-team",namespace=""} 1
+			cattage_tenant_healthy{name="a-team"} 1
+			cattage_tenant_healthy{name="c-team"} 1
+			cattage_tenant_healthy{name="m-team"} 0
+			cattage_tenant_healthy{name="x-team"} 1
+			cattage_tenant_healthy{name="y-team"} 1
 			# HELP cattage_tenant_unhealthy The tenant status about unhealthy condition
 			# TYPE cattage_tenant_unhealthy gauge
-			cattage_tenant_unhealthy{name="a-team",namespace=""} 0
-			cattage_tenant_unhealthy{name="c-team",namespace=""} 0
-			cattage_tenant_unhealthy{name="m-team",namespace=""} 1
-			cattage_tenant_unhealthy{name="x-team",namespace=""} 0
-			cattage_tenant_unhealthy{name="y-team",namespace=""} 0
+			cattage_tenant_unhealthy{name="a-team"} 0
+			cattage_tenant_unhealthy{name="c-team"} 0
+			cattage_tenant_unhealthy{name="m-team"} 1
+			cattage_tenant_unhealthy{name="x-team"} 0
+			cattage_tenant_unhealthy{name="y-team"} 0
 			`
 			expectedReader := strings.NewReader(expected)
 			if err := testutil.GatherAndCompare(k8smetrics.Registry, expectedReader, customMetricsNames...); err != nil {
@@ -691,18 +691,18 @@ var _ = Describe("Tenant controller", Ordered, func() {
 			expected := `
 			# HELP cattage_tenant_healthy The tenant status about healthy condition
 			# TYPE cattage_tenant_healthy gauge
-			cattage_tenant_healthy{name="a-team",namespace=""} 1
-			cattage_tenant_healthy{name="c-team",namespace=""} 1
-			cattage_tenant_healthy{name="m-team",namespace=""} 1
-			cattage_tenant_healthy{name="x-team",namespace=""} 1
-			cattage_tenant_healthy{name="y-team",namespace=""} 1
+			cattage_tenant_healthy{name="a-team"} 1
+			cattage_tenant_healthy{name="c-team"} 1
+			cattage_tenant_healthy{name="m-team"} 1
+			cattage_tenant_healthy{name="x-team"} 1
+			cattage_tenant_healthy{name="y-team"} 1
 			# HELP cattage_tenant_unhealthy The tenant status about unhealthy condition
 			# TYPE cattage_tenant_unhealthy gauge
-			cattage_tenant_unhealthy{name="a-team",namespace=""} 0
-			cattage_tenant_unhealthy{name="c-team",namespace=""} 0
-			cattage_tenant_unhealthy{name="m-team",namespace=""} 0
-			cattage_tenant_unhealthy{name="x-team",namespace=""} 0
-			cattage_tenant_unhealthy{name="y-team",namespace=""} 0
+			cattage_tenant_unhealthy{name="a-team"} 0
+			cattage_tenant_unhealthy{name="c-team"} 0
+			cattage_tenant_unhealthy{name="m-team"} 0
+			cattage_tenant_unhealthy{name="x-team"} 0
+			cattage_tenant_unhealthy{name="y-team"} 0
 			`
 			expectedReader := strings.NewReader(expected)
 			if err := testutil.GatherAndCompare(k8smetrics.Registry, expectedReader, customMetricsNames...); err != nil {
@@ -719,16 +719,16 @@ var _ = Describe("Tenant controller", Ordered, func() {
 			expected := `
 			# HELP cattage_tenant_healthy The tenant status about healthy condition
 			# TYPE cattage_tenant_healthy gauge
-			cattage_tenant_healthy{name="a-team",namespace=""} 1
-			cattage_tenant_healthy{name="c-team",namespace=""} 1
-			cattage_tenant_healthy{name="x-team",namespace=""} 1
-			cattage_tenant_healthy{name="y-team",namespace=""} 1
+			cattage_tenant_healthy{name="a-team"} 1
+			cattage_tenant_healthy{name="c-team"} 1
+			cattage_tenant_healthy{name="x-team"} 1
+			cattage_tenant_healthy{name="y-team"} 1
 			# HELP cattage_tenant_unhealthy The tenant status about unhealthy condition
 			# TYPE cattage_tenant_unhealthy gauge
-			cattage_tenant_unhealthy{name="a-team",namespace=""} 0
-			cattage_tenant_unhealthy{name="c-team",namespace=""} 0
-			cattage_tenant_unhealthy{name="x-team",namespace=""} 0
-			cattage_tenant_unhealthy{name="y-team",namespace=""} 0
+			cattage_tenant_unhealthy{name="a-team"} 0
+			cattage_tenant_unhealthy{name="c-team"} 0
+			cattage_tenant_unhealthy{name="x-team"} 0
+			cattage_tenant_unhealthy{name="y-team"} 0
 			`
 			expectedReader := strings.NewReader(expected)
 			if err := testutil.GatherAndCompare(k8smetrics.Registry, expectedReader, customMetricsNames...); err != nil {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -16,14 +16,14 @@ var (
 		Subsystem: tenantSubsystem,
 		Name:      "healthy",
 		Help:      "The tenant status about healthy condition",
-	}, []string{"name", "namespace"})
+	}, []string{"name"})
 
 	UnhealthyVec = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: metricsNameSpace,
 		Subsystem: tenantSubsystem,
 		Name:      "unhealthy",
 		Help:      "The tenant status about unhealthy condition",
-	}, []string{"name", "namespace"})
+	}, []string{"name"})
 )
 
 func init() {


### PR DESCRIPTION
This PR removes namespace label from custom metrics because the Tenant resource is cluster-scoped.