### PR TITLE
Add delegated namespaces to destinations in AppProject

### DIFF
--- a/controllers/tenant_controller_test.go
+++ b/controllers/tenant_controller_test.go
@@ -221,6 +221,10 @@ var _ = Describe("Tenant controller", Ordered, func() {
 					"namespace": Equal("extra-namespace-y"),
 					"server":    Equal("*"),
 				}),
+				MatchAllKeys(Keys{
+					"namespace": Equal("app-c"),
+					"server":    Equal("*"),
+				}),
 			),
 			"namespaceResourceBlacklist": ConsistOf(
 				MatchAllKeys(Keys{


### PR DESCRIPTION
When permission of team A is delegated to Team B, the namespaces of team A should be added to the destinations field of team B's AppProject resource.