### PR TITLE
Bump argocd version in Makefile from 2.10.2 to 2.11.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Tool versions
 CTRL_RUNTIME_VERSION := $(shell awk '/sigs.k8s.io\/controller-runtime/ {print substr($$2, 2)}' go.mod)
-ARGOCD_VERSION = 2.10.2
+ARGOCD_VERSION = 2.11.7
 
 # Test tools
 BIN_DIR := $(shell pwd)/bin


### PR DESCRIPTION
- `aqua.yaml` is already updated
  https://github.com/cybozu-go/cattage/blob/86ad9244b7a1aa9b1b9f5af58cfa4019fcdce9e9/aqua.yaml#L8

- `make crds` modified nothing

  ```console
  takahiro_yamada@ytk-ubuntu20:~/workspace/cybozu-private/cattage$ 
  k8s:stage0.cybozu-ne.co-stage0.cybozu-ne.co> make crds
  mkdir -p test/crd/
  curl -fsL -o test/crd/application.yaml https://raw.githubusercontent.com/argoproj/argo-cd/v2.11.7/manifests/crds/application-crd.yaml
  curl -fsL -o test/crd/appproject.yaml https://raw.githubusercontent.com/argoproj/argo-cd/v2.11.7/manifests/crds/appproject-crd.yaml
  takahiro_yamada@ytk-ubuntu20:~/workspace/cybozu-private/cattage$ 

  takahiro_yamada@ytk-ubuntu20:~/workspace/cybozu-private/cattage$ 
  k8s:stage0.cybozu-ne.co-stage0.cybozu-ne.co> git status
  On branch bump-argocd
  nothing to commit, working tree clean
  takahiro_yamada@ytk-ubuntu20:~/workspace/cybozu-private/cattage$ 
  ```