### PR TITLE
Fix renovate CI

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -12,4 +12,4 @@ jobs:
         uses: renovatebot/github-action@248bf5a619694187930adc80b9343c37761c173f # renovate v43.0.1
         with:
           configurationFile: renovate.json
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ secrets.RENOVATE_TOKEN_PUBLIC }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,5 +1,6 @@
 name: Renovate
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 10 * * 1'
 jobs:

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
   ],
   "extends": [
     "config:base",
-    "github>aquaproj/aqua-renovate-config#1.6.0",
+    "github>aquaproj/aqua-renovate-config#2.8.2",
     ":semanticCommitTypeAll(chore)",
     ":timezone(Asia/Tokyo)"
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "cybozu-go/cattage"
   ],
   "extends": [
-    "config:base",
+    "config:recommended",
     "github>aquaproj/aqua-renovate-config#2.8.2",
     ":semanticCommitTypeAll(chore)",
     ":timezone(Asia/Tokyo)"
@@ -23,10 +23,10 @@
       "matchDatasources": [
         "go"
       ],
+      "separateMinorPatch": true,
       "matchPackagePatterns": [
         "^k8s\\.io\\/.*"
-      ],
-      "separateMinorPatch": true
+      ]
     },
     {
       "description": "Disable major updates for k8s.io/client-go",
@@ -88,11 +88,12 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "datasourceTemplate": "docker",
       "depNameTemplate": "kindest/node",
-      "fileMatch": [
+      "managerFilePatterns": [
         "^\\.github\\/workflows\\/.+\\.ya?ml$"
       ],
       "matchStrings": [
@@ -100,9 +101,10 @@
       ]
     },
     {
+      "customType": "regex",
       "datasourceTemplate": "docker",
       "depNameTemplate": "kindest/node",
-      "fileMatch": [
+      "managerFilePatterns": [
         "^e2e\\/Makefile$"
       ],
       "matchStrings": [
@@ -110,9 +112,10 @@
       ]
     },
     {
+      "customType": "regex",
       "datasourceTemplate": "docker",
       "depNameTemplate": "kindest/node",
-      "fileMatch": [
+      "managerFilePatterns": [
         "^cluster.yaml$"
       ],
       "matchStrings": [

--- a/renovate.json
+++ b/renovate.json
@@ -4,9 +4,7 @@
   "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "platform": "github",
   "onboarding": false,
-  "repositories": [
-    "cybozu-go/cattage"
-  ],
+  "repositories": ["cybozu-go/cattage"],
   "extends": [
     "config:recommended",
     "github>aquaproj/aqua-renovate-config#2.8.2",
@@ -14,99 +12,63 @@
     ":timezone(Asia/Tokyo)"
   ],
   "ignorePresets": [":prHourlyLimit2"],
-  "labels": [
-    "dependencies"
-  ],
+  "labels": ["dependencies"],
   "packageRules": [
     {
       "description": "Separate minor and patch updates for Kubernetes packages",
-      "matchDatasources": [
-        "go"
-      ],
+      "matchDatasources": ["go"],
       "separateMinorPatch": true,
-      "matchPackagePatterns": [
-        "^k8s\\.io\\/.*"
-      ]
+      "matchPackagePatterns": ["^k8s\\.io\\/.*"]
     },
     {
       "description": "Disable major updates for k8s.io/client-go",
       "enabled": false,
-      "matchDatasources": [
-        "go"
-      ],
-      "matchPackageNames": [
-        "k8s.io/client-go"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ]
+      "matchDatasources": ["go"],
+      "matchPackageNames": ["k8s.io/client-go"],
+      "matchUpdateTypes": ["major"]
     },
     {
       "description": "Separate minor and patch updates for kubectl",
-      "matchPackageNames": [
-        "kubernetes/kubectl"
-      ],
+      "matchPackageNames": ["kubernetes/kubectl"],
       "separateMinorPatch": true
     },
     {
       "description": "Disable major and minor update for kubectl",
       "enabled": false,
-      "matchPackageNames": [
-        "kubernetes/kubectl"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ]
+      "matchPackageNames": ["kubernetes/kubectl"],
+      "matchUpdateTypes": ["major", "minor"]
     },
     {
       "description": "Separate minor and patch update for Kubernetes",
-      "matchPackageNames": [
-        "kindest/node"
-      ],
+      "matchPackageNames": ["kindest/node"],
       "separateMinorPatch": true
     },
     {
       "description": "Disable major and minor update for Kubernetes",
       "enabled": false,
-      "matchPackageNames": [
-        "kindest/node"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor"
-      ]
+      "matchPackageNames": ["kindest/node"],
+      "matchUpdateTypes": ["major", "minor"]
     },
     {
       "description": "Disable updates for argoproj/argo-cd",
       "enabled": false,
-      "matchPackageNames": [
-        "argoproj/argo-cd"
-      ]
+      "matchPackageNames": ["argoproj/argo-cd"]
     }
   ],
-  "postUpdateOptions": [
-    "gomodTidy"
-  ],
+  "postUpdateOptions": ["gomodTidy"],
   "customManagers": [
     {
       "customType": "regex",
       "datasourceTemplate": "docker",
       "depNameTemplate": "kindest/node",
-      "managerFilePatterns": [
-        "^\\.github\\/workflows\\/.+\\.ya?ml$"
-      ],
-      "matchStrings": [
-        "- (?<currentValue>.+?) # renovate: kindest\\/node"
-      ]
+      "managerFilePatterns": ["^\\.github\\/workflows\\/.+\\.ya?ml$"],
+      "matchStrings": ["- (?<currentValue>.+?) # renovate: kindest\\/node"]
     },
     {
       "customType": "regex",
       "datasourceTemplate": "docker",
       "depNameTemplate": "kindest/node",
-      "managerFilePatterns": [
-        "^e2e\\/Makefile$"
-      ],
+      "managerFilePatterns": ["^e2e\\/Makefile$"],
       "matchStrings": [
         "KUBERNETES_VERSION := (?<currentValue>.*?) # renovate: kindest\\/node"
       ]
@@ -115,9 +77,7 @@
       "customType": "regex",
       "datasourceTemplate": "docker",
       "depNameTemplate": "kindest/node",
-      "managerFilePatterns": [
-        "^cluster.yaml$"
-      ],
+      "managerFilePatterns": ["^cluster.yaml$"],
       "matchStrings": [
         "kubernetesVersion: (?<currentValue>.*?) # renovate: kindest\\/node"
       ]


### PR DESCRIPTION
The Renovate workflow has been failing for a long time.
_e.g._, https://github.com/cybozu-go/cattage/actions/runs/15969870283/job/45038455997

```log
[...]
 WARN: Config needs migrating
[...]
 WARN: github.com token 401 unauthorized
ERROR: config-presets-invalid
[...]
```

This pull request addresses the following issues:

- Fixes the 401 error related to the GitHub token
- Migrates deprecated configurations
- Formats the configuration
- Bumps the aqua-renovate-config version

The diff of configuration between current and preferred are gained by running `npx` command written on https://docs.renovatebot.com/config-validation/.

```diff
takahiro_yamada@ytk-ubuntu22:~/work/cybozu-go/cattage$ 
k8s:stage0.cybozu-ne.co-stage0.cybozu-ne.co> diff -u old-config.json new-config.json 
--- old-config.json     2025-07-06 23:52:15.377297038 +0000
+++ new-config.json     2025-07-06 23:51:58.577040936 +0000
@@ -6,7 +6,7 @@
   "onboarding": false,
   "repositories": ["cybozu-go/cattage"],
   "extends": [
-    "config:base",
+    "config:recommended",
     "github>aquaproj/aqua-renovate-config#2.8.2",
     ":semanticCommitTypeAll(chore)",
     ":timezone(Asia/Tokyo)"
@@ -17,8 +17,8 @@
     {
       "description": "Separate minor and patch updates for Kubernetes packages",
       "matchDatasources": ["go"],
-      "matchPackagePatterns": ["^k8s\\.io\\/.*"],
-      "separateMinorPatch": true
+      "separateMinorPatch": true,
+      "matchPackageNames": ["/^k8s\\.io\\/.*/"]
     },
     {
       "description": "Disable major updates for k8s.io/client-go",
@@ -56,25 +56,28 @@
     }
   ],
   "postUpdateOptions": ["gomodTidy"],
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "datasourceTemplate": "docker",
       "depNameTemplate": "kindest/node",
-      "fileMatch": ["^\\.github\\/workflows\\/.+\\.ya?ml$"],
+      "managerFilePatterns": ["/^\\.github\\/workflows\\/.+\\.ya?ml$/"],
       "matchStrings": ["- (?<currentValue>.+?) # renovate: kindest\\/node"]
     },
     {
+      "customType": "regex",
       "datasourceTemplate": "docker",
       "depNameTemplate": "kindest/node",
-      "fileMatch": ["^e2e\\/Makefile$"],
+      "managerFilePatterns": ["/^e2e\\/Makefile$/"],
       "matchStrings": [
         "KUBERNETES_VERSION := (?<currentValue>.*?) # renovate: kindest\\/node"
       ]
     },
     {
+      "customType": "regex",
       "datasourceTemplate": "docker",
       "depNameTemplate": "kindest/node",
-      "fileMatch": ["^cluster.yaml$"],
+      "managerFilePatterns": ["/^cluster.yaml$/"],
       "matchStrings": [
         "kubernetesVersion: (?<currentValue>.*?) # renovate: kindest\\/node"
       ]
takahiro_yamada@ytk-ubuntu22:~/work/cybozu-go/cattage$ 
```