### PR TITLE
Specify`kubernetes-sigs/controller-tools` instead of `kubernetes-sigs/controller-tools/controller-gen` to make renovate can detect them

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -30,7 +30,7 @@
         "kindest/node",
         "argoproj/argo-cd",
         "argo-cd",
-        "kubernetes-sigs/controller-tools/controller-gen",
+        "kubernetes-sigs/controller-tools",
         "aquaproj/aqua-installer",
         "helm/chart-releaser-action",
         "renovatebot/github-action"
@@ -125,7 +125,7 @@
       dependencyDashboardApproval: true,
       description: "Require approval for controller-gen updates",
       matchPackageNames: [
-        "kubernetes-sigs/controller-tools/controller-gen"
+        "kubernetes-sigs/controller-tools"
       ]
     },
     {


### PR DESCRIPTION
#112 unintentionally includes a minor update of `kubernetes-sigs/controller-tools/controller-gen`.
It is caused by that renovate detects packageName or depName of GitHub Release using the `owner/repo` format and not aqua depName like `kubernetes-sigs/controller-tools/controller-gen`.

_cf_. https://docs.renovatebot.com/modules/datasource/github-releases/

This PR also applies the rule to envtest, which is released under `kubernetes-sigs/controller-tools`, and that’s favorable.