### PR TITLE
bump supported Argo CD version from v3.0.23 to v3.3.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Tool versions
 CTRL_RUNTIME_VERSION := $(shell awk '/sigs.k8s.io\/controller-runtime/ {print substr($$2, 2)}' go.mod)
-ARGOCD_VERSION = 3.0.23
+ARGOCD_VERSION = 3.3.6
 
 # Test tools
 BIN_DIR := $(shell pwd)/bin

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -5,7 +5,7 @@ registries:
   - type: standard
     ref: v4.486.0 # renovate: depName=aquaproj/aqua-registry
 packages:
-  - name: argoproj/argo-cd@v3.0.23
+  - name: argoproj/argo-cd@v3.3.6
   - name: clamoriniere/crd-to-markdown@v0.0.3
   - name: GoogleContainerTools/container-structure-test@v1.22.1
   - name: helm/helm@v4.1.3


### PR DESCRIPTION
Bump supported Argo CD version from v3.0.23 to v3.3.6