### PR TITLE
Update renovate config to stop scheduled trigger

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,8 +1,6 @@
 name: Renovate
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 10 * * *'
 jobs:
   renovate:
     runs-on: ubuntu-latest

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -23,5 +23,5 @@ If Argo CD API has changed, please fix the relevant source code.
 
 ## How to update dependencies
 
-Renovate will create PRs that update dependencies once a week.
+Renovate will create PRs that update dependencies when you [trigger the workflow with `workflow_dispatch`](https://github.com/cybozu-go/cattage/actions/workflows/renovate.yaml).
 However, Argo CD is not subject to Renovate. Also, Kubernetes is only updated with patched versions.


### PR DESCRIPTION
Stop scheduled trigger for renovate to avoid running GitHub Actions workflows at arbitrary times for security reasons.

## Changes

- Remove scheduled trigger (cron) from Renovate workflow.
    - `workflow_dispatch` trigger is still allowed for manual execution. 