### PR TITLE
Bump supported Argo CD from v3.3.6 to v3.3.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Tool versions
 CTRL_RUNTIME_VERSION := $(shell awk '/sigs.k8s.io\/controller-runtime/ {print substr($$2, 2)}' go.mod)
-ARGOCD_VERSION = 3.3.6
+ARGOCD_VERSION := $(shell awk -F '@v' '/argoproj\/argo-cd/ {print $$2}' aqua.yaml)
 
 # Test tools
 BIN_DIR := $(shell pwd)/bin

--- a/aqua-checksums.json
+++ b/aqua-checksums.json
@@ -21,6 +21,26 @@
       "algorithm": "sha256"
     },
     {
+      "id": "github_release/github.com/argoproj/argo-cd/v3.3.10/argocd-darwin-amd64",
+      "checksum": "6C83A8EE7033BFCBB37C1434F58438AB37DB2F32F26FB33B4F25C5F7811B3826",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/argoproj/argo-cd/v3.3.10/argocd-darwin-arm64",
+      "checksum": "065A55DC174BA70AE53AFF6332D4CF6E91113CD84534272E4C82C23833A6DC62",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/argoproj/argo-cd/v3.3.10/argocd-linux-amd64",
+      "checksum": "910F9A5EA6193F4B25608FCAC0C3A29B71F63B2A1A5B9232FE2A715C8B0D88AE",
+      "algorithm": "sha256"
+    },
+    {
+      "id": "github_release/github.com/argoproj/argo-cd/v3.3.10/argocd-linux-arm64",
+      "checksum": "FDC81EF30DA8622474F10ED68A9F4ED2EE716D2FCFEC3FC08A786CF7BF900B7E",
+      "algorithm": "sha256"
+    },
+    {
       "id": "github_release/github.com/argoproj/argo-cd/v3.3.6/argocd-darwin-amd64",
       "checksum": "08683B717C2BF7F12A3C77953B3B79576F28FD41864B3F84C6BDC76BCED1CE93",
       "algorithm": "sha256"

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -12,7 +12,7 @@ registries:
   - type: standard
     ref: v4.486.0 # renovate: depName=aquaproj/aqua-registry
 packages:
-  - name: argoproj/argo-cd@v3.3.6
+  - name: argoproj/argo-cd@v3.3.10
   - name: clamoriniere/crd-to-markdown@v0.0.3
   - name: GoogleContainerTools/container-structure-test@v1.22.1
   - name: helm/helm@v4.1.3

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -14,10 +14,10 @@ If Kubernetes or controller-runtime API has changed, please fix the relevant sou
 ## How to update supported Argo CD
 
 Cattage supports one Argo CD version.
-If a new Argo CD is released, please update the following files.
+When a new version of Argo CD is released, follow the steps below:
 
-- Update Argo CD Version in `aqua.yaml` and `Makefile`.
-- Update Supported Version metrics in [README.md](../README.md)
+- Update the Argo CD version in `aqua.yaml` by running `aqua update argocd@${VERSION}`
+- Update the checksums in `aqua-checksums.json` by running `aqua update-checksum`
 
 If Argo CD API has changed, please fix the relevant source code.
 


### PR DESCRIPTION
- Bump supported Argo CD version from v3.3.6 to v3.3.10
- Define `ARGOCD_VERSION` in Makefile dynamically. The `awk` works as follows:

    ```console
    k8s:> awk -F '@v' '/argoproj\/argo-cd/ {print $2}' aqua.yaml
    3.3.10
    ```