### PR TITLE
Run `aqua update-checksum` in renovate postUpgradeTasks

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -9,6 +9,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/aqua
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@abd08c7549b2a864af5df4a2e369c43f035a6a9d # v46.1.5
         with:

--- a/config.json
+++ b/config.json
@@ -3,5 +3,5 @@
   "platform": "github",
   "onboarding": false,
   "repositories": ["cybozu-go/cattage"],
-  "allowedCommands": ["^aqua update-checksum$"]
+  "allowedCommands": ["^aqua update-checksum --prune$"]
 }

--- a/config.json
+++ b/config.json
@@ -2,5 +2,6 @@
   "username": "cybozu-neco",
   "platform": "github",
   "onboarding": false,
-  "repositories": ["cybozu-go/cattage"]
+  "repositories": ["cybozu-go/cattage"],
+  "allowedCommands": ["^aqua update-checksum$"]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -182,7 +182,7 @@
     "gomodTidy"
   ],
   postUpgradeTasks: {
-    "commands": ["aqua update-checksum"],
+    "commands": ["aqua update-checksum --prune"],
     "fileFilters": ["aqua-checksums.json"],
     "executionMode": "branch"
   },

--- a/renovate.json5
+++ b/renovate.json5
@@ -181,6 +181,11 @@
   postUpdateOptions: [
     "gomodTidy"
   ],
+  postUpgradeTasks: {
+    "commands": ["aqua update-checksum"],
+    "fileFilters": ["aqua-checksums.json"],
+    "executionMode": "branch"
+  },
   customManagers: [
     {
       customType: "regex",


### PR DESCRIPTION
Checksum Verification by aqua was enabled in #179, but since renovate does not update the checksum, [CI is failing](https://github.com/cybozu-go/cattage/actions/runs/26855850584/job/79198397360). To fix this, run `aqua update-checksum` in renovate's [postUpgradeTasks](https://docs.renovatebot.com/configuration-options/#postupgradetasks).