### PR TITLE
Mount runner's aqua binary into the renovate container

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -12,7 +12,6 @@ jobs:
       - uses: ./.github/actions/aqua
       - name: Resolve the installation path of `aqua`
         id: resolve-aqua-path
-        # Please refer to https://aquaproj.github.io/docs/products/aqua-installer/#shell-script about the installation path of `aqua`.
         run: echo "AQUA_PATH=$(readlink -f $(which aqua))" >> "$GITHUB_OUTPUT"
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@abd08c7549b2a864af5df4a2e369c43f035a6a9d # v46.1.5

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -10,8 +10,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/aqua
+      - name: Resolve the installation path of `aqua`
+        id: resolve-aqua-path
+        # Please refer to https://aquaproj.github.io/docs/products/aqua-installer/#shell-script about the installation path of `aqua`.
+        run: echo "AQUA_PATH=$(readlink -f ${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin/aqua)" >> "$GITHUB_OUTPUT"
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@abd08c7549b2a864af5df4a2e369c43f035a6a9d # v46.1.5
         with:
           configurationFile: config.json
           token: ${{ secrets.RENOVATE_TOKEN_PUBLIC }}
+          # Mount the aqua installed on the runner into the renovate container so that `aqua update-checksum` can be executed within it.
+          docker-volumes: |
+            /tmp:/tmp ;
+            ${{ steps.resolve-aqua-path.outputs.AQUA_PATH }}:/usr/local/bin/aqua

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Resolve the installation path of `aqua`
         id: resolve-aqua-path
         # Please refer to https://aquaproj.github.io/docs/products/aqua-installer/#shell-script about the installation path of `aqua`.
-        run: echo "AQUA_PATH=$(readlink -f ${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin/aqua)" >> "$GITHUB_OUTPUT"
+        run: echo "AQUA_PATH=$(readlink -f $(which aqua))" >> "$GITHUB_OUTPUT"
       - name: Self-hosted Renovate
         uses: renovatebot/github-action@abd08c7549b2a864af5df4a2e369c43f035a6a9d # v46.1.5
         with:

--- a/config.json
+++ b/config.json
@@ -3,5 +3,5 @@
   "platform": "github",
   "onboarding": false,
   "repositories": ["cybozu-go/cattage"],
-  "allowedCommands": ["^aqua update-checksum --prune$"]
+  "allowedCommands": ["^/usr/local/bin/aqua update-checksum --prune$"]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -182,7 +182,7 @@
     "gomodTidy"
   ],
   postUpgradeTasks: {
-    "commands": ["aqua update-checksum --prune"],
+    "commands": ["/usr/local/bin/aqua update-checksum --prune"],
     "fileFilters": ["aqua-checksums.json"],
     "executionMode": "branch"
   },


### PR DESCRIPTION
Mount runner's aqua installed by aqua-installer into the renovate container to run `aqua update-checksum` within it.

I confirmed that aqua can be executed as follows in my local environment:

```console
❯ docker run --entrypoint /usr/local/bin/aqua -v $(readlink -f "${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin/aqua"):/usr/local/bin/aqua renovate/renovate:43.211-full
NAME:
   aqua - Version Manager of CLI. https://aquaproj.github.io/
```