### PR TITLE
Use GitHub App token for Renovate

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -10,6 +10,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/aqua
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RENOVATE_CLIENT_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
       - name: Resolve the installation path of `aqua`
         id: resolve-aqua-path
         run: echo "AQUA_PATH=$(readlink -f $(which aqua))" >> "$GITHUB_OUTPUT"
@@ -17,7 +23,7 @@ jobs:
         uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:
           configurationFile: config.json
-          token: ${{ secrets.RENOVATE_TOKEN_PUBLIC }}
+          token: ${{ steps.app-token.outputs.token }}
           # Mount the aqua installed on the runner into the renovate container so that `aqua update-checksum` can be executed within it.
           docker-volumes: |
             /tmp:/tmp ;


### PR DESCRIPTION
This PR updates the Renovate workflow to use a GitHub App token instead of `RENOVATE_TOKEN_PUBLIC`.

Using a GitHub App token makes the workflow less dependent on a personal access token and keeps the token short-lived.

I also confirmed that the updated workflow works as expected.
- https://github.com/cybozu-go/cattage/actions/runs/27343483504/job/80785984501